### PR TITLE
웹사이트 도메인 변경(사파리 사이트추척방지때문에)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -9,12 +9,12 @@ const cookieParser = require("cookie-parser");
 const app = express();
 const port = 5000;
 const corsOptions = {
-  origin: "https://dn9g4x7ek29ym.cloudfront.net",
+  origin: "https://jabakexpress.site",
   credentials: true,
 };
+app.use(cors(corsOptions)); //cors 처리
 app.use(express.json()); //서버 요청의 값은 body로 들어온다. body에 넣어주기 위해 사용한다.
 app.use(cookieParser()); //쿠키 사용
-app.use(cors(corsOptions)); //cors 처리
 //라우트 분리
 app.use("/api/users", userRouter);
 app.use("/api/write", writeRouter);


### PR DESCRIPTION
도메인 변경, 원래 기본 도메인을 사용하려했지만 사파리의 정책때문에 통일함.
클라이언트 www , 서버는 api와 server를 붙힘